### PR TITLE
MakeRelease improvements

### DIFF
--- a/ReleaseCreator.rb
+++ b/ReleaseCreator.rb
@@ -26,8 +26,16 @@ end
 
 def getExtraOptions(opts)
 
-  opts.on("--development", "Allow making development, -DMAKE_RELEASE=0, builds") do |b|
+  opts.on("-d", "--development", "Allow making development, -DMAKE_RELEASE=0, builds") do |b|
     $options[:allowDevelopment] = true
+  end
+
+  opts.on("-u", "--unattended", "Don't ask if the folder is fine") do |b|
+    $options[:unattendedMode] = true
+  end
+
+  opts.on("-z", "--zip-path PATH", "Override the final zip's path (including file name and extension)") do |path|
+    $options[:zipPath] = path
   end
 
 end
@@ -299,9 +307,12 @@ def handlePlatform(props, platform, prettyName)
 
   # TODO: allow pausing here for manual testing
   info "Created folder: " + target
-  puts "Now is an excellent time to verify that the folder is fine"
-  puts "If it isn't press CTRL+C to cancel"
-  waitForKeyPress
+
+  if !$options[:unattendedMode]
+    puts "Now is an excellent time to verify that the folder is fine"
+    puts "If it isn't press CTRL+C to cancel"
+    waitForKeyPress
+  end
 
 
   # Then clean all logs and settings
@@ -393,13 +404,15 @@ def handlePlatform(props, platform, prettyName)
 
   end
 
+  zipPath = $options[:zipPath] ? $options[:zipPath] : target + ".7z"
+
   # Zip it up
-  if runSystemSafe(p7zip, "a", target + ".7z", target) != 0
+  if runSystemSafe(p7zip, "a", zipPath, target) != 0
     onError "Failed to zip folder: " + target
   end
 
   puts ""
-  success "Created archive: #{target}.7z"
+  success "Created archive: #{zipPath}"
   info "SHA3: " + SHA3::Digest::SHA256.file(target + ".7z").hexdigest
   puts ""
 end


### PR DESCRIPTION
Adds two new options, --unattended and --zip-path.
--unattended skips the folder verification prompt. Has a shortcut, -u.
--zip-path takes an argument, the path to the zip file,
including file name and extension. Has a shortcut, -z. Example: --zip-path build/ThriveReleaseExample.7z
Shortcut (-d) also added for --development.
Full example: ruby MakeRelease.rb --development --unattended --zip-path build/release/thrive-release-example.7z
Closes Revolutionary-Games/Thrive#811.