### PR TITLE
Fix mistake with SHA3 output

### DIFF
--- a/ReleaseCreator.rb
+++ b/ReleaseCreator.rb
@@ -413,7 +413,7 @@ def handlePlatform(props, platform, prettyName)
 
   puts ""
   success "Created archive: #{zipPath}"
-  info "SHA3: " + SHA3::Digest::SHA256.file(target + ".7z").hexdigest
+  info "SHA3: " + SHA3::Digest::SHA256.file(zipPath).hexdigest
   puts ""
 end
 


### PR DESCRIPTION
I missed the SHA3 output, now it will respect --zip-path.